### PR TITLE
Add CI Travis and indicate Ruby >= 2.4 need

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 2.4
+  - 2.5

--- a/deferral.gemspec
+++ b/deferral.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/tagomoris/deferral"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.4.0" # To use Refine with module (not class)
+
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
See result on my fork at https://travis-ci.org/nicolasleger/deferral/builds/353840040
* You will have to configure Travis on the main repository.